### PR TITLE
Realizado a implementação de uso de telemetria de logs com o OpenTelemetry + Serilog + Loki 

### DIFF
--- a/Employees.Management.API/Employees.Management.API.csproj
+++ b/Employees.Management.API/Employees.Management.API.csproj
@@ -23,6 +23,8 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.5" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
+    <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="3.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/Employees.Management.API/Program.cs
+++ b/Employees.Management.API/Program.cs
@@ -1,6 +1,7 @@
 using Employees.Management.API.Contexts;
 using Employees.Management.API.Extensions;
 using Microsoft.EntityFrameworkCore;
+using Serilog;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -20,6 +21,11 @@ builder.Services.AddHttpClient("PaymentAPI", httpClient =>
 });
 
 builder.Services.AddCustomOpenTelemetry(builder.Configuration);
+
+builder.Host.UseSerilog((context, loggerConfiguration) =>
+{
+    loggerConfiguration.ReadFrom.Configuration(context.Configuration);
+});
 
 var app = builder.Build();
 

--- a/Employees.Management.API/appsettings.json
+++ b/Employees.Management.API/appsettings.json
@@ -7,11 +7,37 @@
     "ServiceName": "employee-management-service",
     "OtlExporterEndpoint": "http://localhost:4317"
   },
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Information",
+        "System": "Information"
+      },
+      "Using": [
+        "Serilog.Sinks.Console",
+        "Serilog.Sinks.OpenTelemetry"
+      ]
+    },
+    "WriteTo": [
+      {
+        //Essa configuração de log no console vou manter somente para que o prompt de comando da API, quando aberto não fique sem informação
+        "Name": "Console",
+        "Args": {
+          "outputTemplate": "{Timestamp:yyyy-MM-dd HH:mm:ss} | {Level} | Trace: {TraceId} | RequestPath: {RequestPath} | {SourceContext} | {Message} | {Exception}{NewLine}"
+        }
+      },
+      {
+        "Name": "OpenTelemetry",
+        "Args": {
+          "Endpoint": "http://localhost:4317", //Caso seja usado o protocolo HttpProtobuf o path completo deve ser informado: /v1/logs
+          "Protocol": "Grpc", //Default
+          "ResourceAttributes": {
+            "service.name": "employee-management-service"
+          }
+        }
+      }
+    ]
+  }
 }

--- a/Payments.Management.API/Payments.Management.API.csproj
+++ b/Payments.Management.API/Payments.Management.API.csproj
@@ -22,6 +22,8 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.5" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.1" />
+    <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
+    <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="3.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/Payments.Management.API/Program.cs
+++ b/Payments.Management.API/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Payments.Management.API.Contexts;
 using Payments.Management.API.Extensions;
+using Serilog;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -14,6 +15,11 @@ builder.Services.AddControllers();
 builder.Services.AddSwaggerGen();
 
 builder.Services.AddCustomOpenTelemetry(builder.Configuration);
+
+builder.Host.UseSerilog((context, loggerConfiguration) =>
+{
+    loggerConfiguration.ReadFrom.Configuration(context.Configuration);
+});
 
 var app = builder.Build();
 

--- a/Payments.Management.API/appsettings.json
+++ b/Payments.Management.API/appsettings.json
@@ -6,11 +6,36 @@
     "ServiceName": "payment-management-service",
     "OtlExporterEndpoint": "http://localhost:4317"
   },
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Information",
+        "System": "Information"
+      },
+      "Using": [
+        "Serilog.Sinks.OpenTelemetry"
+      ]
+    },
+    "WriteTo": [
+      {
+        //Essa configuração de log no console vou manter somente para que o prompt de comando da API, quando aberto não fique sem informação
+        "Name": "Console",
+        "Args": {
+          "outputTemplate": "{Timestamp:yyyy-MM-dd HH:mm:ss} | {Level} | Trace: {TraceId} | RequestPath: {RequestPath} | {SourceContext} | {Message} | {Exception}{NewLine}"
+        }
+      },
+      {
+        "Name": "OpenTelemetry",
+        "Args": {
+          "Endpoint": "http://localhost:4317", //Caso seja usado o protocolo HttpProtobuf o path completo deve ser informado: /v1/logs
+          "Protocol": "Grpc", //Default
+          "ResourceAttributes": {
+            "service.name": "payment-management-service"
+          }
+        }
+      }
+    ]
+  }
 }

--- a/otel/docker-compose.yml
+++ b/otel/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3.8'
 
 services:
+
  # Jaeger
  jaeger:
    container_name: jaeger-tracing
@@ -13,9 +14,33 @@ services:
     container_name: prometheus-metrics
     image: prom/prometheus
     volumes:
-      - "./prometheus.yml:/etc/prometheus/prometheus.yml"
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
     ports:
       - 9090:9090
+
+ # Grafana Loki
+ loki:
+    container_name: loki-logs
+    image: grafana/loki:3.0.0
+    volumes:
+      - ./loki-config.yaml:/conf/loki-config.yaml
+    command: [ "--config.file=/conf/loki-config.yaml" ]
+    ports:
+      - 3100:3100
+
+ # Grafana
+ grafana:
+    container_name: grafana
+    image: grafana/grafana:main-ubuntu
+    user: "0"
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
 
  # Collector
  collector:

--- a/otel/grafana-datasources.yaml
+++ b/otel/grafana-datasources.yaml
@@ -1,0 +1,19 @@
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    orgId: 1
+    url: http://loki:3100
+    basicAuth: false
+    isDefault: true
+    version: 1
+    editable: false
+    apiVersion: 1
+    jsonData:
+      derivedFields:
+        - datasourceUid: otlp
+          matcherRegex: (?:"traceid"):"(\w+)"
+          name: TraceID
+          url: $${__value.raw}

--- a/otel/loki-config.yaml
+++ b/otel/loki-config.yaml
@@ -1,0 +1,50 @@
+limits_config:
+  allow_structured_metadata: true
+
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /tmp/loki
+  storage:
+    filesystem:
+      chunks_directory: /tmp/loki/chunks
+      rules_directory: /tmp/loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+# By default, Loki will send anonymous, but uniquely-identifiable usage and configuration
+# analytics to Grafana Labs. These statistics are sent to https://stats.grafana.org/
+#
+# Statistics help us better understand how Loki is used, and they show us performance
+# levels for most users. This helps us prioritize features and documentation.
+# For more information on what's sent, look at
+# https://github.com/grafana/loki/blob/main/pkg/analytics/stats.go
+# Refer to the buildReport method to see what goes into a report.
+#
+# If you would like to disable reporting, uncomment the following lines:
+#analytics:
+#  reporting_enabled: false

--- a/otel/otel-collector-config.yaml
+++ b/otel/otel-collector-config.yaml
@@ -15,8 +15,14 @@ exporters:
    endpoint: jaeger:4317
    tls:
     insecure: true
+#  Prometheus
  prometheus:
    endpoint: "0.0.0.0:8889"
+
+# Grafana Loki
+ otlphttp:
+   endpoint: http://loki:3100/otlp
+
 service:
  pipelines:
    traces:
@@ -27,3 +33,7 @@ service:
      receivers: [otlp]
      processors: [batch]
      exporters: [prometheus]
+   logs:
+     receivers: [otlp]
+     processors: [batch]
+     exporters: [otlphttp]


### PR DESCRIPTION
Realizado a implementação de uso de telemetria de logs com o OpenTelemetry  e utilizando o storage Loki com o vendor Grafana. Foram feitas as referências necessárias de bibliotecas do OpenTelemetry e Serilog e implementado suas configurações na classe Program dos dois projetos API's.

Foi realizado a configuração do appsettings para definir as informações do Serilog e onde os logs devem ser depositados (Sink), apontando para o Loki.

Quanto aos arquivos de configuração para criação dos containers, foi criado um arquivo de configuração para o Loki e Grafana e acrescentado um novo serviço para eles no docker-compose. O Collector recebeu agora um novo pipeline de coleta, processamento e exportação de logs.