### PR TITLE
Implementado observabilidade no uso de cache com Redis

### DIFF
--- a/Employees.Management.API/Employees.Management.API.csproj
+++ b/Employees.Management.API/Employees.Management.API.csproj
@@ -14,19 +14,21 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.2" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.22" />
-    <PackageReference Include="Npgsql.OpenTelemetry" Version="6.0.10" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.11" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.5" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.0" />
+    <PackageReference Include="Npgsql.OpenTelemetry" Version="6.0.12" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.12" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.7" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc5" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
-    <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="3.0.0" />
+    <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.1.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/Employees.Management.API/Infra/RedisConsts.cs
+++ b/Employees.Management.API/Infra/RedisConsts.cs
@@ -1,0 +1,7 @@
+﻿namespace Employees.Management.API.Infra
+{
+    public class RedisConsts
+    {
+        public const string RedisRootUri = "localhost";
+    }
+}

--- a/Payments.Management.API/Consumers/PaymentMessagingService.cs
+++ b/Payments.Management.API/Consumers/PaymentMessagingService.cs
@@ -1,5 +1,6 @@
 ﻿using Business.Management.Contracts;
 using MassTransit;
+using Microsoft.Extensions.Caching.Distributed;
 using Payments.Management.API.Contexts;
 using Payments.Management.API.Controllers;
 using Payments.Management.API.Domain;
@@ -10,12 +11,14 @@ namespace Payments.Management.API.Consumers
     {
         private readonly AppDbContext _dbContext;
         private readonly ILogger<PaymentController> _logger;
+        private readonly IDistributedCache _distributedCache;
 
-        public PaymentMessagingService(AppDbContext dbContext, ILogger<PaymentController> logger)
+        public PaymentMessagingService(AppDbContext dbContext, ILogger<PaymentController> logger, IDistributedCache distributedCache)
         {
             _dbContext = dbContext;
             _logger = logger;
-        }
+            _distributedCache = distributedCache;
+        }   
         public Task Consume(ConsumeContext<EmployeeAddedEvent> context)
         {
             _logger.LogInformation("Iniciando processo de registro de pagamento via mensageria.");
@@ -27,6 +30,9 @@ namespace Payments.Management.API.Consumers
 
             _dbContext.Payments.Add(payment);
             _dbContext.SaveChanges();
+
+            _logger.LogInformation("Removendo dados de cache para a próxima consulta buscar do bando e atualizar o Redis.");
+            _distributedCache.RemoveAsync("Payment");
 
             _logger.LogInformation("Finalizando processo de registro de pagamento via mensageria.");
 

--- a/Payments.Management.API/Extensions/OpenTelemetryExtension.cs
+++ b/Payments.Management.API/Extensions/OpenTelemetryExtension.cs
@@ -7,12 +7,13 @@ using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using Payments.Management.API.Meters;
+using StackExchange.Redis;
 
 namespace Payments.Management.API.Extensions
 {
     public static class OpenTelemetryExtension
     {
-        public static void AddCustomOpenTelemetry(this IServiceCollection services, ConfigurationManager configuration)
+        public static void AddCustomOpenTelemetry(this IServiceCollection services, ConfigurationManager configuration, IConnectionMultiplexer connection)
         {
             var serviceName = configuration.GetSection("OpenTelemetrySettings").GetChildren().FirstOrDefault(c => c.Key == "ServiceName").Value;
             var otelExporterEndpoint = configuration.GetSection("OpenTelemetrySettings").GetChildren().FirstOrDefault(c => c.Key == "OtlExporterEndpoint").Value;
@@ -27,7 +28,8 @@ namespace Payments.Management.API.Extensions
                         .AddHttpClientInstrumentation()
                         .AddEntityFrameworkCoreInstrumentation(x => x.SetDbStatementForText = true)
                         .AddNpgsql()
-                        .AddSource(DiagnosticHeaders.DefaultListenerName); // MassTransit ActivitySource
+                        .AddSource(DiagnosticHeaders.DefaultListenerName) // MassTransit ActivitySource
+                        .AddRedisInstrumentation(connection, opt => opt.FlushInterval = TimeSpan.FromSeconds(1));
                 })
                 .WithMetrics(builder =>
                 {

--- a/Payments.Management.API/Infra/RedisConsts.cs
+++ b/Payments.Management.API/Infra/RedisConsts.cs
@@ -1,0 +1,7 @@
+﻿namespace Payments.Management.API.Infra
+{
+    public class RedisConsts
+    {
+        public const string RedisRootUri = "localhost";
+    }
+}

--- a/Payments.Management.API/Payments.Management.API.csproj
+++ b/Payments.Management.API/Payments.Management.API.csproj
@@ -14,7 +14,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.2" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.22" />
     <PackageReference Include="Npgsql.OpenTelemetry" Version="6.0.10" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.0" />
@@ -24,6 +26,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.5" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc5" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
     <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="3.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />

--- a/otel/docker-compose.yml
+++ b/otel/docker-compose.yml
@@ -66,5 +66,12 @@ services:
       - 5672:5672
       - 15672:15672
 
+  # Redis Cache
+ redis:
+    container_name: redis
+    image: redis
+    ports:
+      - 6379:6379
+
 
   


### PR DESCRIPTION
Implementado uso básico de cache distribuído apenas como exemplo para… aplicar a telemetria de trace no Redis. O objetivo principal é ter uma configuração na classe de extensão do OpenTelemetry para monitorar o uso do cache distribuído e apoiando na análise de trace com a utilização deste recurso. Para isso as seguintes alterações foram necessárias:

- Import de uma nova biblioteca do OpenTelemetry (StackExchangeRedis).
- Criação de uma configuração de conexão IConnectionMultiplexer.
- Adicionado essa conexão às configurações de telemetria.
- Alterado lógica de inserção e busca de Employee e Payment com a função de buscar do cache primeiro e caso encontre retornar essa lista e caso não vai em banco populando o cache, invalidando o cache caso algum registro seja inserido.
- Incluído no docker-compose o novo serviço do redis.