### PR TITLE
Implementação da utilização do Vendor Grafana Tempo

### DIFF
--- a/otel/dashboard.json
+++ b/otel/dashboard.json
@@ -590,7 +590,167 @@
           "service": "employee-management-service"
         }
       ],
-      "title": "Traces",
+      "title": "Traces - Jaeger",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "tempo",
+        "uid": "tempo"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Trace ID"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 250
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Duration"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ms"
+              },
+              {
+                "id": "custom.width",
+                "value": 120
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Start Time"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "time:YYYY-MM-DD HH:mm:ss"
+              },
+              {
+                "id": "custom.width",
+                "value": 180
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Trace Name"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 300
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "id": 9,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Start Time"
+          }
+        ]
+      },
+      "pluginVersion": "11.4.0-202957",
+      "targets": [
+        {
+          "datasource": {
+            "type": "tempo",
+            "uid": "tempo"
+          },
+          "query": "{ .service.name =~ \"employee-management-service|payment-management-service\" }",
+          "queryType": "traceql",
+          "refId": "A"
+        }
+      ],
+      "title": "Traces - Tempo",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "spanID": true,
+              "serviceName": true,
+              "kind": true,
+              "statusCode": true,
+              "statusMessage": true,
+              "tags": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "traceID": 0,
+              "spanName": 1,
+              "startTime": 2,
+              "duration": 3
+            },
+            "renameByName": {
+              "traceID": "Trace ID",
+              "spanName": "Trace Name",
+              "startTime": "Start Time",
+              "duration": "Duration"
+            }
+          }
+        }
+      ],
       "type": "table"
     },
     {
@@ -607,7 +767,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 30
+        "y": 37
       },
       "id": 4,
       "options": {

--- a/otel/docker-compose.yml
+++ b/otel/docker-compose.yml
@@ -26,6 +26,16 @@ services:
     ports:
       - 3100:3100
 
+  # Grafana Tempo
+ tempo:
+    container_name: tempo-tracing
+    image: grafana/tempo:latest
+    command: [ "-config.file=/etc/tempo.yaml" ]
+    volumes:
+      - ./tempo.yaml:/etc/tempo.yaml
+    ports:
+      - "3200:3200" # Tempo HTTP
+
  # Grafana
  grafana:
     container_name: grafana
@@ -45,7 +55,7 @@ services:
  # Collector
  collector:
    container_name: otel-collector
-   image: otel/opentelemetry-collector
+   image: otel/opentelemetry-collector-contrib
    volumes:
      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
    command: [ "--config=/etc/otel-collector-config.yaml" ]

--- a/otel/grafana-datasources.yaml
+++ b/otel/grafana-datasources.yaml
@@ -44,3 +44,16 @@ datasources:
     editable: false
     jsonData:
       tlsSkipVerify: true
+
+  - name: Tempo
+    type: tempo
+    access: proxy
+    orgId: 1
+    url: http://tempo:3200
+    uid: tempo
+    isDefault: false
+    version: 1
+    editable: true
+    tracing:
+      nodeGraph:
+        enabled: true

--- a/otel/otel-collector-config.yaml
+++ b/otel/otel-collector-config.yaml
@@ -1,39 +1,49 @@
 receivers:
- otlp:
-   protocols:
-     http:
-       endpoint: 0.0.0.0:4318
-     grpc:
-       endpoint: 0.0.0.0:4317
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+      grpc:
+        endpoint: 0.0.0.0:4317
+
 processors:
- batch:
-   send_batch_size: 1024
-   timeout: 5s
+  batch:
+    send_batch_size: 1024
+    timeout: 5s
+
 exporters:
 # Jaeger extension is incompatible with the OpenTelemetry Protocol, using the OTLP extension instead
- otlp/jaeger:
-   endpoint: jaeger:4317
-   tls:
-    insecure: true
-#  Prometheus
- prometheus:
-   endpoint: "0.0.0.0:8889"
+  otlp/jaeger:
+    endpoint: jaeger:4317
+    tls:
+      insecure: true
 
-# Grafana Loki
- otlphttp:
-   endpoint: http://loki:3100/otlp
+  otlp/tempo:
+    endpoint: tempo:4317
+    tls:
+      insecure: true
+
+ #  Prometheus
+  prometheus:
+    endpoint: "0.0.0.0:8889"
+
+ # Grafana Loki
+  otlphttp:
+    endpoint: http://loki:3100/otlp
 
 service:
- pipelines:
-   traces:
-     receivers: [otlp]
-     processors: [batch]
-     exporters: [otlp/jaeger]
-   metrics:
-     receivers: [otlp]
-     processors: [batch]
-     exporters: [prometheus]
-   logs:
-     receivers: [otlp]
-     processors: [batch]
-     exporters: [otlphttp]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp/jaeger, otlp/tempo]
+
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheus]
+
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlphttp]

--- a/otel/tempo.yaml
+++ b/otel/tempo.yaml
@@ -1,0 +1,28 @@
+server:
+  http_listen_port: 3200
+  grpc_listen_port: 9095
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+
+ingester:
+  trace_idle_period: 10s
+  max_block_duration: 5m
+
+compactor:
+  compaction:
+    compaction_window: 1h
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /tmp/tempo/traces
+    wal:
+      path: /tmp/tempo/wal


### PR DESCRIPTION
Implementação do Grafana Tempo como sistema de tracing adicional rodando uma arquitetura híbrida de observabilidade que mantém o Jaeger existente e adiciona as capacidades modernas do Tempo para análise de traces das aplicações .NET 6.

Motivação:

- Diversificação de vendors: Reduzir dependência de um único sistema de tracing
- Funcionalidades avançadas: Aproveitar recursos modernos do Tempo como Node Graph
- Performance otimizada: Beneficiar-se da arquitetura otimizada do Tempo para grandes volumes
- Flexibilidade de análise: Permitir escolha da melhor ferramenta para cada cenário

No otel-collector foi dicionado novo exporter otlp/tempo para enviar traces para o Grafana Tempo via protocolo OTLP/gRPC na porta 4317. E no pipeline de traces agora envia dados simultaneamente para Jaeger (existente) e Tempo (novo), criando redundância.

Configuração do novo vender, o Grafana Tempo. Configuração standalone do Tempo que define:

- Portas de comunicação (3200 HTTP, 9095 gRPC interno)
- Receivers OTLP (aceita traces do Collector)
- Políticas de retenção (10s idle, 5m blocos, 1h compactação)
- Armazenamento local em /tmp/tempo/

Adicionado novo datasource que permite ao Grafana:

- Consultar traces armazenados no Tempo via API HTTP na porta 3200
- Visualizar Node Graph - representação visual de dependências entre serviços
- Integrar com dashboards existentes do Grafana

E por fim, foi adicionado uma nova visão no dashboard de monitoramento existente do Grafana para começar a exibir os traces via Grafana Tempo assim como já é feito no Jaeger.